### PR TITLE
Add get next track of songs

### DIFF
--- a/src/Commands/NextTrack.cs
+++ b/src/Commands/NextTrack.cs
@@ -1,0 +1,42 @@
+﻿using Community.VisualStudio.Toolkit;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+namespace MusicToCodeBy
+{
+    internal sealed class NextTrack : BaseCommand<NextTrack>
+    {
+        private static MusicPlayer _player;
+
+        public NextTrack()
+            : base(PackageGuids.CommandSet, PackageIds.NextTrack) { }
+
+        public static Task InitializeAsync(AsyncPackage package, MusicPlayer player)
+        {
+            _player = player;
+            return InitializeAsync(package);
+        }
+
+        protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
+        {
+            MusicPlayer player = _player;
+
+            if (!player.IsPlaying)
+            {
+                Command.Checked = false;
+                player.Play();
+                return;
+            }
+
+            General options = await General.GetLiveInstanceAsync();
+
+            if (string.IsNullOrEmpty(options.MusicFolder) && !await PickFolder.TryPickFolderAsync())
+            {
+                return;
+            }
+
+            Command.Checked = true;
+            player.NextTrack();
+        }
+    }
+}

--- a/src/MusicPlayer.cs
+++ b/src/MusicPlayer.cs
@@ -77,6 +77,11 @@ namespace MusicToCodeBy
 
             return playlist;
         }
+        
+        public void NextTrack()
+        {
+            _player.controls.next();
+        }
 
         private void OnOptionsSaved(object sender, General e)
         {

--- a/src/MusicToCodeBy.csproj
+++ b/src/MusicToCodeBy.csproj
@@ -46,6 +46,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Commands\NextTrack.cs" />
     <Compile Include="Commands\PickFolder.cs" />
     <Compile Include="Commands\VolumeDown.cs" />
     <Compile Include="Commands\VolumeUp.cs" />

--- a/src/MusicToCodeByPackage.cs
+++ b/src/MusicToCodeByPackage.cs
@@ -24,6 +24,7 @@ namespace MusicToCodeBy
             await VolumeUp.InitializeAsync(this, player);
             await VolumeDown.InitializeAsync(this, player);
             await PickFolder.InitializeAsync(this, player);
+            await NextTrack.InitializeAsync(this, player);
         }
     }
 }

--- a/src/VSCommandTable.cs
+++ b/src/VSCommandTable.cs
@@ -31,5 +31,6 @@ namespace MusicToCodeBy
         public const int VolumeDown = 0x0102;
         public const int PickFolder = 0x0103;
         public const int MusicMenu = 0x1001;
+        public const int NextTrack = 0x0104;
     }
 }

--- a/src/VSCommandTable.vsct
+++ b/src/VSCommandTable.vsct
@@ -62,6 +62,16 @@
           <LocCanonicalName>.MusicToCodeBy.VolumeDown</LocCanonicalName>
         </Strings>
       </Button>
+      
+      <Button guid="CommandSet" id="NextTrack" priority="0x0100" type="Button">
+        <Parent guid="CommandSet" id="MusicMenuGroup" />
+        <Icon guid="ImageCatalogGuid" id="GoToNextInList" />
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <Strings>
+          <ButtonText>Next Track</ButtonText>
+          <LocCanonicalName>.MusicToCodeBy.NextTrack</LocCanonicalName>
+        </Strings>
+      </Button>
 
       <Button guid="CommandSet" id="PickFolder" priority="0x0100" type="Button">
         <Parent guid="CommandSet" id="FolderPickerGroup" />
@@ -91,6 +101,7 @@
       <IDSymbol name="VolumeDown" value="0x0102" />
       <IDSymbol name="PickFolder" value="0x0103" />
       <IDSymbol name="MusicMenu" value="0x1001" />
+      <IDSymbol name="NextTrack" value="0x0104" />
     </GuidSymbol>
   </Symbols>
 </CommandTable>


### PR DESCRIPTION
Hi Mads. Thanks for creating this extension as my comment is what was read on the Dotnetrocks show #1732, on which you mentioned to Carl and Richard, it would be a good idea to create a Music to Code By extension. Since my comment was read on the show, I received a copy of the Music to Code By set.  So, I pulled down your extension and installed it in my VS 2019 Community edition install. I love it but thought it would be good to have a "Next Track" menu option.